### PR TITLE
use concat instead of spread operator

### DIFF
--- a/features/entries/entries_reducer.js
+++ b/features/entries/entries_reducer.js
@@ -17,10 +17,7 @@ export default (state = defaultState, action = {}) => {
     case ADD_QUESTION:
     return {
       ...state,
-      questions: [
-        ...state.questions,
-        payload
-      ]
+      questions: state.questions.concat([payload])
     }
     default: return state;
   }


### PR DESCRIPTION
For future performance. Spread operator has to iterate through all elements. If we had a large list, this would take a hit.